### PR TITLE
Allow using xdebug_filter

### DIFF
--- a/server/src/TestRunner.ts
+++ b/server/src/TestRunner.ts
@@ -137,7 +137,7 @@ export class TestRunner {
 
         params = [
             '-dxdebug.remote_port=8000',
-            //'-dauto_prepend_file=xdebug_filter.php',
+            '-dauto_prepend_file=misc/xdebug_filter.php',
             './vendor/bin/codecept',
             'run',
             'unit',


### PR DESCRIPTION
Use xdebug_filter from misc dir.

While you are at it, can you please add the command line to compile the extension to the README file? :)